### PR TITLE
fix: handle non HDA network configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,5 @@ typings/
 .env
 
 .accounts
-!test/fixture-projects/hardhat-project/.accounts
+!test/fixture-projects/*/.accounts
 cache

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -2,8 +2,19 @@ import cloneDeep from 'lodash.clonedeep'
 import { EthersProviderWrapper } from '@nomiclabs/hardhat-ethers/internal/ethers-provider-wrapper'
 import { Mnemonic } from 'ethers/lib/utils'
 import { createProvider } from 'hardhat/internal/core/providers/construction'
-import { HttpNetworkHDAccountsConfig, Network } from 'hardhat/types'
-import { DEFAULT_HD_COUNT, DEFAULT_HD_INITIAL_INDEX, DEFAULT_HD_PASSPHRASE, removeIndexFromHDPath } from './wallet'
+import {
+  HardhatNetworkAccountsConfig,
+  HardhatNetworkHDAccountsConfig,
+  HttpNetworkAccountsConfig,
+  HttpNetworkHDAccountsConfig,
+  Network,
+} from 'hardhat/types'
+import {
+  DEFAULT_HD_COUNT,
+  DEFAULT_HD_INITIAL_INDEX,
+  DEFAULT_HD_PASSPHRASE,
+  removeIndexFromHDPath,
+} from './wallet'
 
 import { logDebug } from '../helpers/logger'
 import { getWallet } from './wallet'
@@ -29,15 +40,18 @@ function setNetworkMnemonic(_network: Network, mnemonic: Mnemonic): Network {
   const network = cloneDeep(_network)
 
   logDebug(`Injecting mnemonic into network config for ${network.name}`)
-  let networkAccounts = network.config.accounts as HttpNetworkHDAccountsConfig
+  let networkAccounts = network.config.accounts
 
-  if ('mnemonic' in networkAccounts) {
+  if (
+    isHardhatNetworkHDAccountsConfig(networkAccounts) ||
+    isHttpNetworkHDAccountsConfig(networkAccounts)
+  ) {
     logDebug('Target network already uses HD accounts, overriding mnemonic')
     networkAccounts.mnemonic = mnemonic.phrase
     networkAccounts.path = removeIndexFromHDPath(mnemonic.path)
   } else {
     logDebug('Target network not using HD accounts, setting mnemonic')
-    networkAccounts = {
+    network.config.accounts = {
       mnemonic: mnemonic.phrase,
       initialIndex: DEFAULT_HD_INITIAL_INDEX,
       count: DEFAULT_HD_COUNT,
@@ -46,4 +60,17 @@ function setNetworkMnemonic(_network: Network, mnemonic: Mnemonic): Network {
     }
   }
   return network
+}
+
+// Type guards
+function isHardhatNetworkHDAccountsConfig(
+  accountsConfig: HardhatNetworkAccountsConfig | HttpNetworkAccountsConfig,
+): accountsConfig is HardhatNetworkHDAccountsConfig {
+  return (accountsConfig as HardhatNetworkHDAccountsConfig).mnemonic !== undefined
+}
+
+function isHttpNetworkHDAccountsConfig(
+  accountsConfig: HardhatNetworkAccountsConfig | HttpNetworkAccountsConfig,
+): accountsConfig is HttpNetworkHDAccountsConfig {
+  return (accountsConfig as HttpNetworkHDAccountsConfig).mnemonic !== undefined
 }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -18,7 +18,7 @@ export const TASK_ACCOUNTS_UNLOCK_WALLETS = 'accounts:unlock:wallets'
 export const TASK_ACCOUNTS_UNLOCK_PROVIDER = 'accounts:unlock:provider'
 
 task(TASK_ACCOUNTS, 'Manage local accounts')
-  .addOptionalPositionalParam('action', 'Action to perform: list, import, delete')
+  .addOptionalPositionalParam('action', 'Action to perform: list, new, delete')
   .addOptionalParam('name', 'Name of the account')
   .addOptionalParam('password', 'Password to encrypt the account')
   .setAction(async (taskArgs, hre) => {

--- a/test/environment.test.ts
+++ b/test/environment.test.ts
@@ -1,17 +1,32 @@
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
+import { HardhatNetworkAccountsConfig } from 'hardhat/types'
 import { useEnvironment } from './helpers'
 
-import { TEST_MNEMONIC, TEST_ADDRESSES, TEST_NAME, TEST_PASSWORD, TEST_SIGNED_MESSAGE } from './mnemonics'
+import {
+  TEST_MNEMONIC,
+  TEST_ADDRESSES,
+  TEST_NAME,
+  TEST_PASSWORD,
+  TEST_SIGNED_MESSAGE,
+} from './mnemonics'
 
 chai.use(chaiAsPromised)
 
-describe('Extended environment usage', function () {
+describe('Extended environment usage > project using mnemonic', function () {
   useEnvironment('hardhat-project', 'hardhat')
+  runTests()
+})
 
+describe('Extended environment usage > project using private keys', function () {
+  useEnvironment('hardhat-project-pkeys', 'hardhat')
+  runTests()
+})
+
+function runTests() {
   it('should unlock account and return a single wallet', async function () {
     const wallet = await this.hre.accounts.getWallet(TEST_NAME, TEST_PASSWORD)
-  
+
     expect(wallet.address).to.equal(TEST_ADDRESSES[0])
     expect(wallet.mnemonic.phrase).to.equal(TEST_MNEMONIC)
     expect(wallet.provider).to.be.null
@@ -33,7 +48,7 @@ describe('Extended environment usage', function () {
 
   it('should unlock account and return a single signer', async function () {
     const signer = await this.hre.accounts.getSigner(this.hre.network, TEST_NAME, TEST_PASSWORD)
- 
+
     expect(signer.address).to.equal(TEST_ADDRESSES[0])
     expect(signer.signMessage('test')).to.eventually.equal(TEST_SIGNED_MESSAGE)
     expect(signer.provider).to.not.be.null
@@ -41,7 +56,7 @@ describe('Extended environment usage', function () {
 
   it('should unlock account and return multiple signers', async function () {
     const signers = await this.hre.accounts.getSigners(this.hre.network, TEST_NAME, TEST_PASSWORD)
- 
+
     expect(signers.length).to.equal(20)
 
     for (let i = 0; i < 20; i++) {
@@ -56,11 +71,10 @@ describe('Extended environment usage', function () {
 
     expect(provider).to.not.be.null
     expect(provider).to.be.an('object')
-    
+
     const signer = provider.getSigner()
     expect(signer.getAddress()).to.eventually.equal(TEST_ADDRESSES[0])
     expect(signer.signMessage('test')).to.eventually.equal(TEST_SIGNED_MESSAGE)
     expect(signer.provider).to.not.be.null
   })
-
-})
+}

--- a/test/fixture-projects/hardhat-project-pkeys/.accounts/test-account.json
+++ b/test/fixture-projects/hardhat-project-pkeys/.accounts/test-account.json
@@ -1,0 +1,28 @@
+{
+  "address": "c108fda1b5b2903751594298769efd4904b146bd",
+  "id": "37ec99f7-8244-4982-b2d4-173c244784f3",
+  "version": 3,
+  "Crypto": {
+    "cipher": "aes-128-ctr",
+    "cipherparams": { "iv": "1eb9d55c0882a50e7988a09e674c2402" },
+    "ciphertext": "822fd907f44e48d15d500433200ac244b70487813982936a88c0830fa9cd66b6",
+    "kdf": "scrypt",
+    "kdfparams": {
+      "salt": "f6d158afdf9a11d3353fbe736cbb769626c8428015603c6449ca1fa0b42e3c2e",
+      "n": 131072,
+      "dklen": 32,
+      "p": 1,
+      "r": 8
+    },
+    "mac": "1af4526f4e62b6722226ee1c3a18d7f5dfff0d5b7862ca123989e7a464153f28"
+  },
+  "x-ethers": {
+    "client": "ethers.js",
+    "gethFilename": "UTC--2022-08-24T12-27-39.0Z--c108fda1b5b2903751594298769efd4904b146bd",
+    "mnemonicCounter": "3bd3b82c7148351fe0cdc005a631d445",
+    "mnemonicCiphertext": "f2bc1c5598c60fe265bf7908344fde6d",
+    "path": "m/44'/60'/0'/0/0",
+    "locale": "en",
+    "version": "0.1"
+  }
+}

--- a/test/fixture-projects/hardhat-project-pkeys/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-project-pkeys/hardhat.config.ts
@@ -1,0 +1,33 @@
+import { HardhatUserConfig } from 'hardhat/types'
+
+import '../../../src/index'
+
+import { HARDHAT_PRIVATE_KEYS } from '../../mnemonics'
+
+const config: HardhatUserConfig = {
+  solidity: '0.7.3',
+  defaultNetwork: 'hardhat',
+  paths: {
+    accounts: '.accounts',
+  },
+  networks: {
+    hardhat: {
+      accounts: [
+        {
+          privateKey: HARDHAT_PRIVATE_KEYS[0],
+          balance: '100000000000',
+        },
+        {
+          privateKey: HARDHAT_PRIVATE_KEYS[1],
+          balance: '100000000000',
+        },
+        {
+          privateKey: HARDHAT_PRIVATE_KEYS[2],
+          balance: '100000000000',
+        },
+      ],
+    },
+  },
+}
+
+export default config

--- a/test/mnemonics.ts
+++ b/test/mnemonics.ts
@@ -30,3 +30,9 @@ export const TEST_SIGNED_MESSAGE = '0x6086b97f59a07520ea9df5e069c4b6a9bcb6046912
 // Mnemonic to set on hardhat network
 export const HARDHAT_MNEMONIC =
   'dust pass blood gate carry daughter claim income similar capable east salad'
+
+export const HARDHAT_PRIVATE_KEYS = [
+  '0x70cc4d7e39e1adc999a3397231f7b710f13e0d6e0888e700d1075ffa7f60da5c',
+  '0x172c812fe8e8a1fdc205ec196c4fe536ba75f4061cb969b1308adc67c642bb25',
+  '0xea57407c4471585357d6030a72597b0a63b1511882ecfe9cf6c29a467ca79649'
+]


### PR DESCRIPTION
Type assertion was hiding a bug, added type guards instead.

Signed-off-by: Tomás Migone <tomas@edgeandnode.com>